### PR TITLE
move renderable methods to a concern

### DIFF
--- a/app/controllers/concerns/spree/api/v2/renderable.rb
+++ b/app/controllers/concerns/spree/api/v2/renderable.rb
@@ -1,0 +1,51 @@
+module Spree
+  module Api
+    module V2
+      module Renderable
+        extend ActiveSupport::Concern
+
+        protected
+
+        def render_collection(collection = [])
+          collection = collection.where(filter_params).paginate(page_params)
+          render json: collection, include: params[:include],
+                 meta: { page: page_details(collection) }
+        end
+
+        def render_instance(object = {})
+          render json: object, include: params[:include]
+        end
+
+        private
+
+        def error_response(resource)
+          Spree::ErrorSerializer.new(resource).as_json
+        end
+
+        def filter_params
+          params.fetch(:filter, {}).permit(filter_attributes << :id).transform_values do |value|
+            value.split(',')
+          end
+        end
+
+        def filter_attributes
+          serializer = "Spree::#{controller_name.camelize.singularize}Serializer"
+          serializer.constantize._attributes
+        end
+
+        def page_details(collection)
+          {
+            total_items: collection.total_count,
+            total_pages: collection.total_pages,
+            number: (page_params[:number] || 1).to_i,
+            size: (page_params[:size] || Kaminari.config.default_per_page).to_i
+          }
+        end
+
+        def page_params
+          params.fetch(:page, {}).permit(:number, :size)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/v2/base_controller.rb
+++ b/app/controllers/spree/api/v2/base_controller.rb
@@ -2,6 +2,8 @@ module Spree
   module Api
     module V2
       class BaseController < Spree::Api::BaseController
+        include Spree::Api::V2::Renderable
+
         protected
 
         def index(collection = [])
@@ -22,46 +24,6 @@ module Spree
           TEXT
 
           render_instance object
-        end
-
-        def render_collection(collection = [])
-          collection = collection.where(filter_params).paginate(page_params)
-          render json: collection, include: params[:include],
-                 meta: { page: page_details(collection) }
-        end
-
-        def render_instance(object = {})
-          render json: object, include: params[:include]
-        end
-
-        private
-
-        def error_response(resource)
-          Spree::ErrorSerializer.new(resource).as_json
-        end
-
-        def filter_params
-          params.fetch(:filter, {}).permit(filter_attributes << :id).transform_values do |value|
-            value.split(',')
-          end
-        end
-
-        def filter_attributes
-          serializer = "Spree::#{controller_name.camelize.singularize}Serializer"
-          serializer.constantize._attributes
-        end
-
-        def page_details(collection)
-          {
-            total_items: collection.total_count,
-            total_pages: collection.total_pages,
-            number: (page_params[:number] || 1).to_i,
-            size: (page_params[:size] || Kaminari.config.default_per_page).to_i
-          }
-        end
-
-        def page_params
-          params.fetch(:page, {}).permit(:number, :size)
         end
       end
     end

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spree_api_v2.gemspec
+++ b/spree_api_v2.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'json_spec', '~> 1.1.4'
-  s.add_development_dependency 'shoulda-matchers'
+  s.add_development_dependency 'shoulda-matchers', '~> 3.0.0'
 end


### PR DESCRIPTION
This allows constructing API endpoints in your own app a lot easier. I currently have a controller the extends from a resource controller. Over time, I want to deprecate the resource controller and just use the Spree::Api::V2::BaseController. To help combat this, I've made a module where you can include all the methods inside. This makes migrating to the new API a lot easier.
