### PR TITLE
Remove unused development dependencies

### DIFF
--- a/solidus_json_api.gemspec
+++ b/solidus_json_api.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_api', '~> 1.0'
   s.add_dependency 'active_model_serializers', '= 0.10.0.rc2'
 
-  s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl', '~> 4.5'

--- a/solidus_json_api.gemspec
+++ b/solidus_json_api.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails',  '~> 3.3'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'sass-rails', '~> 5.0.0.beta1'
-  s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pg'


### PR DESCRIPTION
This removes capybara and seleniuv-webdriver. I would have liked to remove coffee-rails and sass-rails, but solidus_auth_devise required them.

Before: 17 Gemfile dependencies, 112 gems now installed.
After: 15 Gemfile dependencies, 105 gems now installed.
